### PR TITLE
Update to not use deprecated Android v1 embedding

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 		 FlutterApplication and put your custom class here. -->
 
 	<application
-		android:name="io.flutter.app.FlutterApplication"
+		android:name="${applicationName}"
 		android:label="wear_example"
 		android:icon="@mipmap/ic_launcher">
 		<activity
@@ -31,7 +31,8 @@
 				 gap between the end of Android's launch screen and the painting of
 				 Flutter's first frame. -->
 			<meta-data
-				android:name="io.flutter.embedding.android.SplashScreenDrawable"
+				android:name="flutterEmbedding"
+				android:value="2"
 				android:resource="@drawable/launch_background"
 			/>
 			<intent-filter>


### PR DESCRIPTION
Fixes the example project failing to build due to this error: "Build failed due to use of deprecated Android v1 embedding."