### PR TITLE
Remove standalone metadata from manifest and add to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ There currently three widgets provided by the plugin:
 * AmbientMode: builder that provides what mode the watch is in. The widget will rebuild whenever the watch changes mode.
 
 
+## Setup
+
+If you are creating a standalone watch app, add the following to your manifest:
+
+```xml
+<application>
+  <meta-data
+    android:name="com.google.android.wearable.standalone"
+    android:value="true"
+    />
+</application>
+```
+
 ## Example
 
 Typically, all three of these widgets would be used near the root of your app's widget tree:
@@ -48,8 +61,7 @@ automatically adds all required references and settings.
 
 1. `build.gradle`: _wearable dependencies_
 
-2. `AndroidManifest.xml`: _`WAKE_LOCK` and `android.hardware.type.watch`
-   and `com.google.android.wearable.standalone`._
-
+2. `AndroidManifest.xml`: _`WAKE_LOCK` and `android.hardware.type.watch`_
+   
 3. `MainActivity.kt` or `MainActivity.java`: _all `AmbientMode` references._
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,14 +2,6 @@
 	package="com.mjohnsullivan.flutterwear.wear"
 	>
 
-	<!-- Makes this app work standalone without a mobile companion app -->
-	<application>
-		<meta-data
-			android:name="com.google.android.wearable.standalone"
-			android:value="true"
-			/>
-	</application>
-
 	<!-- Flags the app as a Wear app -->
 	<uses-feature android:name="android.hardware.type.watch" />
 


### PR DESCRIPTION
It should not be assumed that users of this plugin are creating standalone watch apps