### PR TITLE
Replace "three widgets" with "two widgets" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://medium.com/flutter-community/flutter-building-wearos-app-fedf0f06d1b4
 
 # Widgets
 
-There currently three widgets provided by the plugin:
+There currently two widgets provided by the plugin:
 
 * WatchShape: determines whether the watch is square or round.
 * AmbientMode: builder that provides what mode the watch is in. The widget will rebuild whenever the watch changes mode.
@@ -20,7 +20,7 @@ There currently three widgets provided by the plugin:
 
 ## Example
 
-Typically, all three of these widgets would be used near the root of your app's widget tree:
+Typically, both of those widgets would be used near the root of your app's widget tree:
 
 ```dart
 class WatchScreen extends StatelessWidget {


### PR DESCRIPTION
Since InheritedShape is deprecated and no longer used