### PR TITLE
android kotlin version updated from 1.5.10 to 1.7.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.mjohnsullivan.flutterwear.wear'
 version '1.0-SNAPSHOT'
 
 buildscript {
-	ext.kotlin_version = '1.5.10'
+	ext.kotlin_version = '1.7.10'
 	repositories {
 		google()
 		mavenCentral()


### PR DESCRIPTION
This was causing an issue while compiling any flutter app for wearos.

```console
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':wear' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10
```